### PR TITLE
Make `on_query_context` give a value when view not managed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -571,7 +571,7 @@ class CoqEvaluateInputHandler(sublime_plugin.TextInputHandler):
 class CoqContext(sublime_plugin.EventListener):
     def on_query_context(self, view, key, operator, operand, match_all):
         if key == 'coq':
-            value = view.settings().get('coq')
+            value = view.settings().get('coq') or 'not_managed'
         elif key == 'coq_error':
             value = bool(CoqtopManager.coqtop_view.find_by_selector('message.error'))
         else:


### PR DESCRIPTION
This allows keymaps to bind differently on non-managed views,
for example:

```
{ "keys": ["super+ctrl+h"], "command": "coq_go_here",
  "context": [{ "key": "coq", "operator": "equal", "operand": "editor" }] },
{ "keys": ["super+ctrl+h"], "command": "coq_start",
  "context": [
      { "key": "selector", "operator": "equal", "operand": "source.coq"},
      { "key": "coq", "operator": "equal", "operand": "not_managed" }
   ] 
}
```