### PR TITLE
Reset read_only when stopping

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -227,6 +227,7 @@ class CoqStopCommand(ManagerCommand):
 
         manager.stop()
         del managers[self.view.buffer_id()]
+        self.view.set_read_only(False)
 
 def plugin_unloaded():
     for manager in list(managers.values()):


### PR DESCRIPTION
Assume you start coqtop, do a few steps, move the cursor in the "proven" region (at this point the plugin sets the view to read-only) and then stop coqtop.
That would leave you with a read-only view.
This PR solves it by resetting the read-only on coq_stop.