### PR TITLE
Bugfixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -263,6 +263,9 @@ class CoqCommand(ManagerCommand):
         if position is None:
             position = manager.position
         position = manager.editor_view.find(r'\s*', position).end()
+        # Bug in ST3: find returns Region(-1,-1) when not found
+        if position < 0 or position is None:
+            return None
         return manager.editor_view.find(re, position)
 
     def _substr_find_at_pos(self, re, position=None):

--- a/__init__.py
+++ b/__init__.py
@@ -322,7 +322,7 @@ class CoqNextStatementCommand(CoqCommand):
 
         comment_region   = self._find_at_pos(RE_COMMENT)
         statement_region = self._find_statement()
-        regions = filter(lambda x: x, [comment_region, statement_region])
+        regions = list(filter(lambda x: x, [comment_region, statement_region]))
         if not regions:
             return
         region = min(regions, key=lambda x: x.begin())


### PR DESCRIPTION
Solves two issues:

- `coq_next_sentence` wraps around the buffer
- unhandled exception when cleaning up proven regions